### PR TITLE
fix bash error in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           # we run it twice, so that it will report on the logs
           echo "changed and uncommitted files"
           git status --short          
-          if [ $(git status --short) != '' ]; then
+          if [ -n "$(git status --short)" ]; then
             # print the diff so we can fix it, if there is an issue
             git diff
             exit 1


### PR DESCRIPTION
Note that this may trigger CI failures because of regenerated files, but that would mean this is fixed, and should go in.