### PR TITLE
Makefile: introduce 'make proto' target for generating protocols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
+proto-container:
+	docker build -f .devcontainer/Dockerfile -t eve-api-builder .
+	docker run --rm -v $(PWD):/src -w /src -u $$(id -u) eve-api-builder make proto
+
 proto-diagram:
 	protodot -inc /usr/local/include -src ./proto/config/devconfig.proto -output devconfig -generated ./images
 	dot ./images/devconfig.dot -Tpng -o ./images/devconfig.png
 	dot ./images/devconfig.dot -Tsvg -o ./images/devconfig.svg
 	echo generated ./images/devconfig.*
 
-.PHONY: proto-api-%
+.PHONY: proto-api-% proto proto-container
 
 proto: go python proto-diagram
 	@echo Done building protobuf, you may want to vendor it into your packages, e.g. pkg/pillar.


### PR DESCRIPTION
This is an attempt to simplify the protocol files generation out of the protobuf. The idea is that ANY developer should be able EASILY generate desired files by SIMPLY calling `make` or `make proto`.

CC: @milan-zededa 
CC: @deitch 
CC: @eriknordmark 