### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
+# yamllint disable rule:line-length
+---
 name: Build and Test
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, synchronize, reopened]
   push:
@@ -29,14 +31,14 @@ jobs:
       - name: check no uncommitted files
         run: |
           echo "changed and uncommitted files, excluding versions"
-          diff=$(git diff -I'^\/\/\s+protoc(-gen-go)?\s+v[0-9]+\.[0-9+\.[0-9]+\s*$')
-          if [ -n "diff" ]; then
+          diff=$(git diff -I'^\/\/\s+protoc(-gen-go)?\s+v[0-9]+\.[0-9+\.[0-9]+\s*$' -- . ':!*.png' ':!*.svg')
+          if [ -n "$diff" ]; then
             # print the diff so we can fix it, if there is an issue
             echo
-            echo "differences other than tool version changes:"
-            git diff -I'^\/\/\s+protoc(-gen-go)?\s+v[0-9]+\.[0-9+\.[0-9]+\s*$'
+            echo "differences other than image and tool version changes:"
+            git diff -I'^\/\/\s+protoc(-gen-go)?\s+v[0-9]+\.[0-9+\.[0-9]+\s*$' -- . ':!*.png' ':!*.svg'
             echo
-            echo "differences including tool version changes:"
+            echo "all differences:"
             git diff
             exit 1
           fi

--- a/.github/workflows/yetus.yaml
+++ b/.github/workflows/yetus.yaml
@@ -6,37 +6,36 @@
 #   https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
 # yamllint enable rule:line-length
 ---
-    name: Apache Yetus
-    on:  # yamllint disable-line rule:truthy
-      pull_request:
-        branches:
-          - main
-    
-    jobs:
-      yetus:
-        runs-on: ubuntu-20.04
-        steps:
-          - name: Checkout
-            uses: actions/checkout@v3
-            with:
-              path: src
-              fetch-depth: 0
-    
-          - name: Yetus
-            uses: apache/yetus-test-patch-action@0.14.1
-            with:
-              basedir: ./src
-              bufbasedir: ./src/proto
-              buildtool: nobuild
-              continuousimprovement: true
-              githubtoken: ${{ secrets.GITHUB_TOKEN }}
-              patchdir: ./out
-              reviveconfig: .revive.toml
-    
-          - name: Store Yetus artifacts
-            if: ${{ always() }}
-            uses: actions/upload-artifact@v3
-            with:
-              name: 'yetus-scan'
-              path: ${{ github.workspace }}/out
-    
+name: Apache Yetus
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  yetus:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: src
+          fetch-depth: 0
+
+      - name: Yetus
+        uses: apache/yetus-test-patch-action@0.14.1
+        with:
+          basedir: ./src
+          bufbasedir: ./src/proto
+          buildtool: nobuild
+          continuousimprovement: true
+          githubtoken: ${{ secrets.GITHUB_TOKEN }}
+          patchdir: ./out
+          reviveconfig: .revive.toml
+
+      - name: Store Yetus artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'yetus-scan'
+          path: ${{ github.workspace }}/out


### PR DESCRIPTION
Seems like the diff check in ci.yaml is using a constant and not a variable. Fixes issue #20 
And we want to exclude the images from the comparison since the buider produces different output each time it is run with identical source files.

Second commit was just checking yamllint and discovering that the indentation etc is off for yetus.yaml.