### PR TITLE
README: fix the slightly misleading doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import (
 To make changes to this API, you:
 
 1. Edit the specific `.proto` files in the [proto](./proto) directory, or create new ones, as desired.
-1. Run `make proto` to generate the language-specific bindings and visualizations.
+1. Run `make` to generate the language-specific bindings and visualizations.
 1. Commit the changes to the `.proto` files and the generated files.
 
 The Pull Request process for this repository will regenerate the language-specific bindings and visualizations,
@@ -74,7 +74,7 @@ make python
 
 ### Visualizations
 
-In addition to the language-specific libraries, `make proto` generates visualizations of the protobuf structure,
+In addition to the language-specific libraries, `make` generates visualizations of the protobuf structure,
 beginning with the root of an edge device config. These are
 available as `.svg`, `.dot` and `.png` as below. Click to zoom in.
 

--- a/go/README.md
+++ b/go/README.md
@@ -18,7 +18,7 @@ import (
 To build, go to the root directory of this repository and:
 
 ```bash
-make proto
+make
 ```
 
 To vendor the result into a downstream dependency, e.g. pillar, do the following:


### PR DESCRIPTION
`make proto` command runs protocol generation based on the tools installed on your local machine, which is not what really expected, because tools can be outdated.

`make` calls a `make proto` from a container, so all tools are of the correct versions.

This patch changes `make proto` to just `make` in all docs.

CC: @deitch 