### PR TITLE
Setting all-zeroes gateway IP for NI is not allowed

### DIFF
--- a/go/config/netinst.pb.go
+++ b/go/config/netinst.pb.go
@@ -559,12 +559,11 @@ type NetworkInstanceConfig struct {
 	// type of ipSpec
 	IpType AddressType `protobuf:"varint,39,opt,name=ipType,proto3,enum=org.lfedge.eve.config.AddressType" json:"ipType,omitempty"`
 	// network ip specification
-	// If ip.gateway is set to all-zeroes IP, default route will not be propagated
-	// to applications for interfaces connected to this network instance.
-	// Default route propagation is also automatically suppressed when the network
-	// instance is air-gapped or when the uplink is app-shared without default route
-	// configured. This behaviour can be further customized using static_routes
-	// (see below).
+	// Note that ip.gateway must be a valid IP address and can not be all-zeroes.
+	// To suppress automatic propagation of the default route into apps, configure network
+	// instance as air-gapped (without uplink) or mark the uplink as app-shared
+	// (not for management) and ensure that it will not get a default route
+	// (e.g. set ip.gateway of the attached NetworkConfig to all-zeroes IP).
 	Ip *Ipspec `protobuf:"bytes,40,opt,name=ip,proto3" json:"ip,omitempty"`
 	// static DNS entry, if we are running DNS/DHCP service
 	Dns []*ZnetStaticDNSEntry `protobuf:"bytes,41,rep,name=dns,proto3" json:"dns,omitempty"`
@@ -588,16 +587,13 @@ type NetworkInstanceConfig struct {
 	// routes can be propagated at the same time, there are no restrictions for using both.
 	//
 	// Note that the default route (with the bridge IP as the gateway) is automatically
-	// propagated to connected applications with these exceptions:
+	// propagated to connected applications, unless network instance is air-gapped
+	// (without uplink) or the uplink is app-shared (not management) and does not have
+	// a default route of its own. In both cases, it is possible to enforce default
+	// route propagation by configuring a static default route for the network instance.
 	//
-	//	a) default route propagation is explicitly disabled by setting
-	//	   NetworkInstanceConfig.ip.gateway to an all-zeroes IP
-	//	b) network instance is air-gapped (without uplink)
-	//	c) the uplink is app-shared (not management) and does not have a default route
-	//	   of its own
-	//
-	// In the b) and c) cases, it is possible to enforce default route propagation
-	// by configuring a static default route for the network instance.
+	// For more info on static and connected routes please refer to:
+	// https://wiki.lfedge.org/display/EVE/Connected+and+Static+IP+Route
 	//
 	// This option is only valid for local network instances. For other types
 	// of network instances, it will be ignored.

--- a/proto/config/netinst.proto
+++ b/proto/config/netinst.proto
@@ -113,12 +113,11 @@ message NetworkInstanceConfig {
   AddressType ipType = 39;
 
   // network ip specification
-  // If ip.gateway is set to all-zeroes IP, default route will not be propagated
-  // to applications for interfaces connected to this network instance.
-  // Default route propagation is also automatically suppressed when the network
-  // instance is air-gapped or when the uplink is app-shared without default route
-  // configured. This behaviour can be further customized using static_routes
-  // (see below).
+  // Note that ip.gateway must be a valid IP address and can not be all-zeroes.
+  // To suppress automatic propagation of the default route into apps, configure network
+  // instance as air-gapped (without uplink) or mark the uplink as app-shared
+  // (not for management) and ensure that it will not get a default route
+  // (e.g. set ip.gateway of the attached NetworkConfig to all-zeroes IP).
   ipspec ip = 40;
 
   // static DNS entry, if we are running DNS/DHCP service
@@ -143,14 +142,13 @@ message NetworkInstanceConfig {
   // routes can be propagated at the same time, there are no restrictions for using both.
   //
   // Note that the default route (with the bridge IP as the gateway) is automatically
-  // propagated to connected applications with these exceptions:
-  //  a) default route propagation is explicitly disabled by setting
-  //     NetworkInstanceConfig.ip.gateway to an all-zeroes IP
-  //  b) network instance is air-gapped (without uplink)
-  //  c) the uplink is app-shared (not management) and does not have a default route
-  //     of its own
-  // In the b) and c) cases, it is possible to enforce default route propagation
-  // by configuring a static default route for the network instance.
+  // propagated to connected applications, unless network instance is air-gapped
+  // (without uplink) or the uplink is app-shared (not management) and does not have
+  // a default route of its own. In both cases, it is possible to enforce default
+  // route propagation by configuring a static default route for the network instance.
+  //
+  // For more info on static and connected routes please refer to:
+  // https://wiki.lfedge.org/display/EVE/Connected+and+Static+IP+Route
   //
   // This option is only valid for local network instances. For other types
   // of network instances, it will be ignored.


### PR DESCRIPTION
Previous commit "Clarification on default route propagation" is wrong - EVE does not allow to set all-zeroes gateway IP for network instance (parsing would fail among other things). To suppress default route propagation to apps, NI should be without uplink or the uplink should be configured as app-shared with all-zeroes gateway (in NetworkConfig unspecified GW is allowed).

This is defined in a design document for static and connected routes: https://wiki.lfedge.org/display/EVE/Connected+and+Static+IP+Route