### PR TITLE
Makefile: Fix Fontconfig error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 proto-container:
 	docker build -f .devcontainer/Dockerfile -t eve-api-builder .
-	docker run --rm -v $(PWD):/src -w /src -u $$(id -u) eve-api-builder make proto
+	docker run --rm --env HOME=/src -v $(PWD):/src -w /src -u $$(id -u) eve-api-builder make proto
 
 proto-diagram:
 	protodot -inc /usr/local/include -src ./proto/config/devconfig.proto -output devconfig -generated ./images


### PR DESCRIPTION
Define HOME env. variable to the working directory of the proto container in order to avoid Fontconfig errors due to cache writing, like the following:

```
dot ./images/devconfig.dot -Tpng -o ./images/devconfig.png Fontconfig error: No writable cache directories
Fontconfig error: No writable cache directories
```

Setting HOME to the working directory fixes the problem.

More detailed logs:
```
docker build -f .devcontainer/Dockerfile -t eve-api-builder .
[+] Building 1.4s (13/13) FINISHED                                                                     docker:default
 => [internal] load build definition from Dockerfile                                                             0.0s
 => => transferring dockerfile: 981B                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile:1.6.0                                                   0.7s
 => CACHED docker-image://docker.io/docker/dockerfile:1.6.0@sha256:ac85f380a63b13dfcefa89046420e1781752bab20212  0.0s
 => [internal] load metadata for docker.io/library/alpine:3.18                                                   0.4s
 => [internal] load .dockerignore                                                                                0.0s
 => => transferring context: 2B                                                                                  0.0s
 => [1/7] FROM docker.io/library/alpine:3.18@sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7  0.0s
 => CACHED [2/7] RUN apk add --no-cache bash curl git go make graphviz ttf-freefont                              0.0s
 => CACHED [3/7] RUN arch=$(uname -m);   if [ "${arch: -3:1}" != "_" ]; then     arch="${arch%??}_${arch: -2:2}  0.0s
 => CACHED [4/7] RUN git clone https://github.com/seamia/protodot.git /protodot                                  0.0s
 => CACHED [5/7] RUN go build -C /protodot -o /usr/local/bin/protodot .                                          0.0s
 => CACHED [6/7] RUN mkdir -p $(go env GOPATH)                                                                   0.0s
 => CACHED [7/7] RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0 && mv /root/go/bin/protoc-  0.0s
 => exporting to image                                                                                           0.0s
 => => exporting layers                                                                                          0.0s
 => => writing image sha256:bbae8f5db38ee627c9ba9f1ee8a2ae04e856d48d8ea905a21c15d6bc98d3bdee                     0.0s
 => => naming to docker.io/library/eve-api-builder                                                               0.0s
docker run --rm -v /home/rene/workspace/eve-api:/src -w /src -u $(id -u) eve-api-builder make proto
rm -rf go/*/; mkdir -p go # building proto-api-go
protoc -I./proto --go_out=paths=source_relative:./go proto/*/*.proto
rm -rf python/*/; mkdir -p python # building proto-api-python
protoc -I./proto --python_out=./python proto/*/*.proto
protodot -inc /usr/local/include -src ./proto/config/devconfig.proto -output devconfig -generated ./images
dot ./images/devconfig.dot -Tpng -o ./images/devconfig.png
Fontconfig error: No writable cache directories
Fontconfig error: No writable cache directories
dot ./images/devconfig.dot -Tsvg -o ./images/devconfig.svg
Fontconfig error: No writable cache directories
Fontconfig error: No writable cache directories
echo generated ./images/devconfig.*
generated ./images/devconfig.dot ./images/devconfig.dot.svg ./images/devconfig.png ./images/devconfig.svg
Done building protobuf, you may want to vendor it into your packages, e.g. pkg/pillar.
See ./go/README.md for more information.
```