### PR TITLE
Remove comment about maintenance mode reason

### DIFF
--- a/go/info/info.pb.go
+++ b/go/info/info.pb.go
@@ -1184,7 +1184,6 @@ func (BootReason) EnumDescriptor() ([]byte, []int) {
 }
 
 // Different reasons why we are in maintenance mode
-// Must match the values in pkg/pillar/types.MaintenceModeReason
 type MaintenanceModeReason int32
 
 const (

--- a/proto/info/info.proto
+++ b/proto/info/info.proto
@@ -704,7 +704,6 @@ enum BootReason {
 }
 
 // Different reasons why we are in maintenance mode
-// Must match the values in pkg/pillar/types.MaintenceModeReason
 enum MaintenanceModeReason {
   MAINTENANCE_MODE_REASON_NONE = 0;
   MAINTENANCE_MODE_REASON_USER_REQUESTED = 1;


### PR DESCRIPTION
Remove comment about maintenance mode reason, the API should be source of truth for the definition, not EVE, and as of https://github.com/lf-edge/eve/pull/4462 that is the case.
