### PR TITLE
GitHub Actions: bump runners ubuntu version to latest available

### DIFF
--- a/.github/workflows/yetus.yaml
+++ b/.github/workflows/yetus.yaml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   yetus:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Accoring to [1] Ubuntu 20.04 runners in GitHub will be fully unsuppoerted by 2025-04-01. This commit bumps GitHub-provided runners to latest available Ubuntu 24.04

I am not changing runners to latest because fixed version guarantees stability of packages across workflow runs

[1] - https://github.com/actions/runner-images/issues/11101