### PR TITLE
Makefile: add go-vet target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 proto-container:
 	docker build -f .devcontainer/Dockerfile -t eve-api-builder .
-	docker run --rm --env HOME=/src -v $(PWD):/src -w /src -u $$(id -u) eve-api-builder make proto
+	docker run --rm --env HOME=/tmp -v $(PWD):/src -w /src -u $$(id -u) eve-api-builder make proto
 
 proto-diagram:
 	protodot -inc /usr/local/include -src ./proto/config/devconfig.proto -output devconfig -generated ./images
@@ -10,12 +10,15 @@ proto-diagram:
 
 .PHONY: proto-api-% proto proto-container
 
-proto: go python proto-diagram
+proto: go go-vet python proto-diagram
 	@echo Done building protobuf, you may want to vendor it into your packages, e.g. pkg/pillar.
 	@echo See ./go/README.md for more information.
 
 go: PROTOC_OUT_OPTS=paths=source_relative:
 go: proto-api-go
+go-vet:
+	go mod tidy -C go/
+	go vet -C go ./...
 
 python: proto-api-python
 


### PR DESCRIPTION
run `go vet` on the generated code so that we're not surprised if f.e. an import cycle was created

change $HOME when running in docker as $HOME/go should not be the directory for the created go code as it is an internal directory